### PR TITLE
Fix typo in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ And add this to your `.rubocop.yml`:
 require:
   - rubocop/rspec/focused
 
-Rspec/Focused:
+RSpec/Focused:
   Enabled: true
 ```
 


### PR DESCRIPTION
Cop name is case sensitive, and must therefore be spelled with a capital ‘S’ in `RSpec`.