### PR TITLE
Use keyword arguments for Cop#add_offense

### DIFF
--- a/lib/rubocop/cop/rspec/focused.rb
+++ b/lib/rubocop/cop/rspec/focused.rb
@@ -31,7 +31,7 @@ module RuboCop
           _receiver, method_name, _object, *metadata = *method
 
           if FOCUSED_METHODS.include?(method_name) || focus_set_to_true?(metadata)
-            add_offense(node, :expression, MESSAGE)
+            add_offense(node, location: :expression, message: MESSAGE)
           end
         end
 

--- a/rubocop-rspec-focused.gemspec
+++ b/rubocop-rspec-focused.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rubocop", ">= 0.37"
+  spec.add_runtime_dependency "rubocop", ">= 0.51"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
RuboCop introduced the keyword arguments in 0.51 (bbatsov/rubocop#4786) and will remove positional arguments in 0.52 (bbatsov/rubocop#4911).