### PR TITLE
Add link to rubocop-rspec gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 RuboCop lint for focused specs.
 
-It finds `focus: true` and the following method calls:
+Note: This functionality has also been implemented in the more general [rubocop-rspec](https://github.com/backus/rubocop-rspec) gem (as [RSpec/Focus](https://github.com/backus/rubocop-rspec/blob/master/lib/rubocop/cop/rspec/focus.rb)).
+
+This gem finds `focus: true` and the following method calls:
 
   * `focus`
   * `fexample`


### PR DESCRIPTION
Hey!

This gem is great, and offers a very specific functionality, so first of all, thanks!

I thought you might find it beneficial to:
- inform users of this gem that there are other RSpec RuboCop features available, primarily for their benefit, so they can make an informed decision of what they want.
- potentially avoid the need to maintain this gem, and focus (excuse the pun!) your efforts by contributing to the `rubocop-rspec` gem instead, for instance contributing any improvements from this gem.

Thanks!