### PR TITLE
CI: Update matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 rvm:
-  - jruby-9.1.14.0
+  - jruby-9.2.7.0
   - jruby-head
   - 2.1.10
   - 2.2.8
-  - 2.3.5
-  - 2.4.2
+  - 2.3.8
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
   - ruby-head
 
 cache: bundler


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rvm/rvm/blob/master/config/known